### PR TITLE
feat: conditionally include diagram in output example

### DIFF
--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -60,6 +60,14 @@ type:
 - ...
 description: |
   ...
+{%- if add_diagram %}
+diagram: |
+  sequenceDiagram
+  participant A as ComponentA
+  participant B as ComponentB
+  A->>B: functionCall()
+  B-->>A: response
+{%- endif %}
 title: |
   ...
 {%- if enable_semantic_files_types %}
@@ -141,6 +149,14 @@ type:
 - ...
 description: |
   ...
+{%- if add_diagram %}
+diagram: |
+  sequenceDiagram
+  participant A as ComponentA
+  participant B as ComponentB
+  A->>B: functionCall()
+  B-->>A: response
+{%- endif %}
 title: |
   ...
 {%- if enable_semantic_files_types %}


### PR DESCRIPTION
### **User description**
## 개요

PR description의 `Example output`에 `diagram` 필드를 조건부로 추가했습니다.  
`add_diagram` 변수가 true일 때만 Mermaid 시퀀스 다이어그램이 YAML 결과에 포함되도록 `{% if %}` 조건 분기 처리를 적용했습니다.

## 작업 내용

- `system` / `user` 프롬프트 모두의 출력 예시에 `diagram` 필드 추가
- `{% if add_diagram %}` 조건으로 다이어그램 출력 여부 제어
- Mermaid 형식의 다이어그램 예시 삽입

## 고민한 점

사실 작업하다 보니, 출력 예시에는 diagram을 굳이 추가하지 않아도 된다는 생각이 들었습니다.
프롬프트에서 description 안에 다이어그램을 잘 넣으라고 유도만 해도 충분히 출력되기 때문입니다.

하지만 팀 기여 분담상 마땅히 손댈 부분이 없어… 그냥 확장성 명분으로 이걸 추가했습니다. 😅
("다이어그램 필드가 명시적으로 있는 게 확장에 유리하지 않을까?" 하는 식으로 우겨 보면 어떨까 생각했습니다. ㅋㅋ ;;;;;)

작업하면서 선웅 님과 지한 님 코드 참고했습니다!


___

### **PR Type**
enhancement


___

### **Description**
- Add conditional `diagram` field to example output

- Use `{% if add_diagram %}` to control diagram inclusion

- Insert Mermaid sequence diagram example when enabled


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description_prompts.toml</strong><dd><code>Add conditional diagram field to output example templates</code></dd></summary>
<hr>

pr_agent/settings/pr_description_prompts.toml

<li>Added conditional block for <code>diagram</code> field in output examples<br> <li> Inserted Mermaid sequence diagram as example content<br> <li> Applied changes to both system and user prompt sections<br> <li> Controlled diagram output with <code>add_diagram</code> variable


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/1/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>