### PR TITLE
feat: add add_diagram configuration option to PR description

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -73,6 +73,7 @@ class PRDescription:
             "related_tickets": "",
             "include_file_summary_changes": len(self.git_provider.get_diff_files()) <= self.COLLAPSIBLE_FILE_LIST_THRESHOLD,
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
+            "add_diagram": get_settings().config.get('pr_description.add_diagram', True),
         }
 
         self.user_description = self.git_provider.get_user_description()


### PR DESCRIPTION
### **User description**
## 개요

PR 설명에 다이어그램 추가 설정 옵션 구현

## 작업 내용
- add_diagram 설정을 통해 다이어그램 생성 제어 가능
- 기본값을 True로 설정하여 기존 동작 유지


___

### **PR Type**
enhancement


___

### **Description**
- Added `add_diagram` configuration option for PR descriptions

- Allows control over diagram generation in PR descriptions

- Defaults to True to maintain existing behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Add `add_diagram` config to PR description context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Introduced <code>add_diagram</code> config option in PR description context<br> <li> Fetches value from settings, defaults to True if not set<br> <li> Enables toggling diagram generation in PR descriptions


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/4/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>