### PR TITLE
feat: conditionally append Mermaid sequence diagram instruction in prompt

### DIFF
--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -44,7 +44,7 @@ class FileDescription(BaseModel):
 
 class PRDescription(BaseModel):
     type: List[PRType] = Field(description="one or more types that describe the PR content. Return the label member value (e.g. 'Bug fix', not 'bug_fix')")
-    description: str = Field(description="summarize the PR changes in up to four bullet points, each up to 8 words. For large PRs, add sub-bullets if needed. Order bullets by importance, with each bullet highlighting a key change group.")
+    description: str = Field(description="summarize the PR changes in up to four bullet points, each up to 8 words. For large PRs, add sub-bullets if needed. Order bullets by importance, with each bullet highlighting a key change group. {% if add_diagram %} Also, generate a Mermaid sequence diagram that focuses on the main function call flow between classes or components. {% endif %}")
     title: str = Field(description="a concise and descriptive title that captures the PR's main theme")
 {%- if enable_semantic_files_types %}
     pr_files: List[FileDescription] = Field(max_items=20, description="a list of all the files that were changed in the PR, and summary of their changes. Each file must be analyzed regardless of change size.")


### PR DESCRIPTION
### User description
LLM 프롬프트 컨텍스트에 시퀀스 다이어그램 생성을 요청하는 문장을 추가했습니다.
이 요청은 add_diagram 옵션이 true인 경우에만 전송됩니다.

Java와 JavaScript 대상으로 테스트한 결과, 단순히 "시퀀스 다이어그램 생성하라"고만 요청할 경우 LLM이 코드 diff를 단편적으로 해석해 구조를 잘못 파악하는 경향이 있었습니다. 그로 인해 잘못된 호출 흐름이 생성되거나 Mermaid 문법에 맞지 않아 오류가 발생하는 사례가 나타났습니다. 이를 보완하기 위해 "메인 호출 흐름에 집중할 것"이라는 지시를 프롬프트에 추가했습니다.

#### 고민
시퀀스 다이어그램이 생성되는 위치가 적절한지 확인 부탁드립니다.
현재는 description의 마지막 불릿 포인트로 출력되는데, 불릿 포인트 형식 때문에 들여쓰기가 생겨 약간 어색하게 느껴집니다.
그래서 아예 불릿 포인트 없이 description 하단에 다이어그램을 추가하는 방식도 고려해볼 만한 것 같습니다.

### **PR Type**
enhancement


___

### **Description**
- Add conditional Mermaid sequence diagram instruction to PR description prompt

- Improve prompt flexibility for diagram generation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description_prompts.toml</strong><dd><code>Add conditional Mermaid diagram instruction to PR description prompt</code></dd></summary>
<hr>

pr_agent/settings/pr_description_prompts.toml

<li>Add conditional logic to include Mermaid diagram instruction in PR <br>description<br> <li> Update description field to support diagram generation based on <br><code>add_diagram</code> flag


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/5/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>